### PR TITLE
Bug in GLCameraRipple

### DIFF
--- a/GLCameraRipple/Ripple.cs
+++ b/GLCameraRipple/Ripple.cs
@@ -220,9 +220,9 @@ namespace GLCameraRipple
 		        }
 		    }
 		    
-			var tmp = rippleDest;
+			var tmp = rippleSource;
 			rippleSource = rippleDest;
-			rippleSource = tmp;
+			rippleDest = tmp;
 		}
 
 		public void InitiateRippleAtLocation (PointF location)


### PR DESCRIPTION
Error I noticed while translating this sample to F#:
rippleDest and rippleSource would be the same array after the first simulation, which should mess up the water simulation
