### PR TITLE
Fix sqlite data sample to not insert duplicate rows

### DIFF
--- a/Data/Screens/SQLiteNet/BasicOperations.cs
+++ b/Data/Screens/SQLiteNet/BasicOperations.cs
@@ -80,6 +80,10 @@ namespace Xamarin.Screens.SQLiteNet
 				// create the tables
 				db.CreateTable<Person> ();
 				
+				// skip inserting data if it already exists
+				if(db.Table<Person>().Count() > 0)
+					return;
+					
 				// declare vars
 				List<Person> people = new List<Person> ();
 				Person person;


### PR DESCRIPTION
The sqlite sample has a bug where it will insert more records into the table every time the app starts up. This is easily prevented by doing a count \* and exiting early if records exist.
