### PR TITLE
Possible fix for Reachability.InternetConnectionStatus() always returns NetworkStatus.ReachableViaWiFiNetwork

### DIFF
--- a/ReachabilitySample/reachability.cs
+++ b/ReachabilitySample/reachability.cs
@@ -132,6 +132,8 @@ public static class Reachability {
 				return NetworkStatus.NotReachable;
 		} else if ((flags & NetworkReachabilityFlags.IsWWAN) != 0)
 			return NetworkStatus.ReachableViaCarrierDataNetwork;
+		else if (flags == 0)
+			return NetworkStatus.NotReachable;
 		return NetworkStatus.ReachableViaWiFiNetwork;
 	}
 	


### PR DESCRIPTION
It seems that Reachability.InternetConnectionStatus() always returns NetworkStatus.ReachableViaWiFiNetwork even when the WiFi is turned off. Basically this method will return NetworkStatus.ReachableViaWiFiNetwork by default, i.e. it seems to assume that the WiFi is always on unless something happens to say WiFi isn't. 

Added a check, and if the NetworkAvailabilityFlags == 0 then return NetworkStatus.NotReachable.

(also fixed a typo in a method name while I was at it)
