### PR TITLE
Fix for Peak Level being incorrect.

### DIFF
--- a/AVTouchSample/LevelMeter.cs
+++ b/AVTouchSample/LevelMeter.cs
@@ -123,7 +123,7 @@ namespace avTouch
 					insetAmount = 1;
 				
 				if (PeakLevel > 0){
-					peakLight = (int) PeakLevel * NumLights;
+                    peakLight = (int)(PeakLevel * NumLights); 
 					if (peakLight >= NumLights)
 						peakLight = NumLights-1;
 				}


### PR DESCRIPTION
Math is incorrect with out this change, peakLevel (a number between
0-1) almost always converts to int 0
