### PR TITLE
Fix sound recording in IOS8

### DIFF
--- a/Sound/Sound/SoundViewController.cs
+++ b/Sound/Sound/SoundViewController.cs
@@ -147,7 +147,7 @@ namespace Sound
         {
             //Declare string for application temp path and tack on the file extension
             string fileName = string.Format("Myfile{0}.aac", DateTime.Now.ToString("yyyyMMddHHmmss"));
-            string tempRecording = NSBundle.MainBundle.BundlePath + "/../tmp/" + fileName;
+            string tempRecording = System.IO.Path.GetTempPath() + fileName;
 
             Console.WriteLine(tempRecording);
             this.audioFilePath = NSUrl.FromFilename(tempRecording);


### PR DESCRIPTION
The temporary path is not correct for IOS8 which causes PrepareToRecord
method to fail.
