### PR TITLE
Add required call and setting for iOS 8

### DIFF
--- a/AirLocate/AirLocate/AppDelegate.cs
+++ b/AirLocate/AirLocate/AppDelegate.cs
@@ -18,6 +18,7 @@ namespace AirLocate {
 		public override void FinishedLaunching (UIApplication application)
 		{
 			locationManager = new CLLocationManager ();
+            locationManager.RequestWhenInUseAuthorization ();
 
 			// A user can transition in or out of a region while the application is not running.
 			// When this happens CoreLocation will launch the application momentarily, call this delegate method

--- a/AirLocate/AirLocate/Info.plist
+++ b/AirLocate/AirLocate/Info.plist
@@ -9,7 +9,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>MinimumOSVersion</key>
-	<string>7.0</string>
+	<string>8.0</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.apple.AirLocate</string>
 	<key>UISupportedInterfaceOrientations</key>
@@ -25,5 +25,7 @@
 		<string>Icon-Small@2x</string>
 		<string>Icon-Small-50</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Using Core Location for iBeacons</string>
 </dict>
 </plist>


### PR DESCRIPTION
iOS 8 requires apps using Core Location to make an authorization request on the location manager in conjunction with a setting in the Info.plist to describe the usage reason.