### PR TITLE
[WatchKitCatalog] Fixed GlanceController Awake method

### DIFF
--- a/WatchKit/WatchKitCatalog/WatchkitExtension/Glance/GlanceController.cs
+++ b/WatchKit/WatchKitCatalog/WatchkitExtension/Glance/GlanceController.cs
@@ -22,7 +22,7 @@ namespace WatchkitExtension
 		{
 			bool large = (WKInterfaceDevice.CurrentDevice.ScreenBounds.Size.Width > 136.0);
 			// Load image inside WatchKit Extension
-			using (var image = UIImage.FromBundle (large ? "42mm-Walkway" : "38mm-Walkway"))
+			using (var image = UIImage.FromBundle ("Walkway"))
 			using (var png = image.AsPNG ())
 				glanceImage.SetImage (png);
 		}


### PR DESCRIPTION
Fixed GlanceController Awake method as it was not finding the image Walkaway, it was throwing a NullException, preventing the app to start in the watch simulator.

Changed to the same value that is being used in the ImageDetailController.