### PR TITLE
iOS 9 background updates fix

### DIFF
--- a/Location/Location/LocationManager.cs
+++ b/Location/Location/LocationManager.cs
@@ -20,6 +20,12 @@ namespace Location
 				//locMgr.RequestWhenInUseAuthorization (); // only in foreground
 			}
 
+			// iOS 9 requires the following for background location updates
+			// By default this is set to false and will not allow background updates
+			if (UIDevice.CurrentDevice.CheckSystemVersion (9, 0)) {
+				locMgr.AllowsBackgroundLocationUpdates = true;
+			}
+
 			LocationUpdated += PrintLocation;
 
 		}


### PR DESCRIPTION
New in iOS 9 and required to enable background location updates:

https://developer.apple.com/library/prerelease/ios/documentation/CoreLocation/Reference/CLLocationManager_Class/index.html#//apple_ref/occ/instp/CLLocationManager/allowsBackgroundLocationUpdates