### PR TITLE
Fix use of RegisterDefaults.

### DIFF
--- a/AppPrefs/AppDelegate.cs
+++ b/AppPrefs/AppDelegate.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Foundation;
 using UIKit;
 
@@ -12,7 +9,7 @@ namespace AppPrefs
 	/// application events from iOS.
 	/// </summary>
 	[Register ("AppDelegate")]
-	public partial class AppDelegate : UIApplicationDelegate
+	public class AppDelegate : UIApplicationDelegate
 	{
 		// class-level declarations
 		NSObject observer;
@@ -21,6 +18,7 @@ namespace AppPrefs
 
 		public override void FinishedLaunching (UIApplication application)
 		{
+			Settings.LoadDefaultValues();
 			observer = NSNotificationCenter.DefaultCenter.AddObserver ((NSString)"NSUserDefaultsDidChangeNotification", DefaultsChanged);
 			DefaultsChanged (null);
 		}

--- a/AppPrefs/AppPrefsViewController.cs
+++ b/AppPrefs/AppPrefsViewController.cs
@@ -1,5 +1,4 @@
 using UIKit;
-using CoreGraphics;
 using System;
 using Foundation;
 

--- a/AppPrefs/Settings.cs
+++ b/AppPrefs/Settings.cs
@@ -1,4 +1,3 @@
-using System;
 using Foundation;
 
 namespace AppPrefs
@@ -31,7 +30,7 @@ namespace AppPrefs
 		const string nameColorKey = "nameColorKey";
 		const string backgroundColorKey = "backgroundColorKey";
 
-		static void LoadDefaultValues ()
+		public static void LoadDefaultValues ()
 		{
 			var settingsDict = new NSDictionary (NSBundle.MainBundle.PathForResource ("Settings.bundle/Root.plist", null));
 
@@ -61,14 +60,10 @@ namespace AppPrefs
 			var appDefaults = new NSDictionary (firstNameKey, FirstName, lastNameKey, LastName, nameColorKey, (int)TextColor, backgroundColorKey, (int)BackgroundColor);
 
 			NSUserDefaults.StandardUserDefaults.RegisterDefaults (appDefaults);
-			NSUserDefaults.StandardUserDefaults.Synchronize ();
 		}
 
 		public static void SetupByPreferences ()
 		{
-			var testValue = NSUserDefaults.StandardUserDefaults.StringForKey (firstNameKey);
-			if (testValue == null)
-				LoadDefaultValues ();
 			FirstName = NSUserDefaults.StandardUserDefaults.StringForKey (firstNameKey);
 			LastName = NSUserDefaults.StandardUserDefaults.StringForKey (lastNameKey);
 			TextColor = (TextColors)(int)NSUserDefaults.StandardUserDefaults.IntForKey (nameColorKey);


### PR DESCRIPTION
RegisterDefaults should be called unconditionally before querying NSUserDefaults. Otherwise if you happen to set the first name in settings then none of the other defaults will work unless the user happened to set them all.

I have seen at least two people on the forums get confused by this issue (one example: https://forums.xamarin.com/discussion/58886/nsuserdefaults-standarduserdefaults-value-returns-null). The first time I thought it was their own misunderstanding, but the second one made me realize it was this example that was leading them down the wrong track. I think this pull request makes the proper usage of this API clearer.