### PR TITLE
[Fix] Do not use 'Link All' to ensure that reflection works.

### DIFF
--- a/FileSystemSampleCode/FileSystem/Classes/Account.cs
+++ b/FileSystemSampleCode/FileSystem/Classes/Account.cs
@@ -1,8 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using Foundation;
+
 namespace FileSystem
 {
+	// We use the Preserve attribute to ensure that all the properties of the object
+	// are preserve even when the linker is ran on the assembly. The reasoning
+	// for this pattern is to ensure that libraries, such as Newsoft.Json, that use
+	// reflection can find properties that could be removed by the linker.
+	[Preserve]
 	public class Account
 	{
 		#region Computed Properties
@@ -19,4 +26,3 @@ namespace FileSystem
 		#endregion
 	}
 }
-

--- a/FileSystemSampleCode/FileSystem/FileSystem.csproj
+++ b/FileSystemSampleCode/FileSystem/FileSystem.csproj
@@ -21,7 +21,6 @@
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchLink>Full</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
     <ConsolePause>False</ConsolePause>
     <MtouchArch>i386</MtouchArch>


### PR DESCRIPTION
As stated in bug [37242](https://bugzilla.xamarin.com/show_bug.cgi?id=37242) the sample does not work because the different
properties are read only. This happens when the linker is set to link
everything because the different getter methods are not used.

In this case, we want to keep those methods that are not used so that
the json library, which uses reflection, can find readable properties.