### PR TITLE
Updated SimpleBackgroundTransfer Image URL

### DIFF
--- a/SimpleBackgroundTransfer/SimpleBackgroundTransfer/Info.plist
+++ b/SimpleBackgroundTransfer/SimpleBackgroundTransfer/Info.plist
@@ -23,10 +23,5 @@
 		<string>Icon-60@2x</string>
 		<string>Icon-Small-40@2x</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 </dict>
 </plist>

--- a/SimpleBackgroundTransfer/SimpleBackgroundTransfer/Info.plist
+++ b/SimpleBackgroundTransfer/SimpleBackgroundTransfer/Info.plist
@@ -23,5 +23,10 @@
 		<string>Icon-60@2x</string>
 		<string>Icon-Small-40@2x</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/SimpleBackgroundTransfer/SimpleBackgroundTransfer/SimpleBackgroundTransferViewController.cs
+++ b/SimpleBackgroundTransfer/SimpleBackgroundTransfer/SimpleBackgroundTransferViewController.cs
@@ -8,7 +8,7 @@ namespace SimpleBackgroundTransfer {
 	public partial class SimpleBackgroundTransferViewController : UIViewController {
 
 		const string Identifier = "com.SimpleBackgroundTransfer.BackgroundSession";
-		const string DownloadUrlString = "https://atmire.com/dspace-labs3/bitstream/handle/123456789/7618/earth-map-huge.jpg";
+		const string DownloadUrlString = "https://upload.wikimedia.org/wikipedia/commons/9/97/The_Earth_seen_from_Apollo_17.jpg";
 
 		public NSUrlSessionDownloadTask downloadTask;
 		public NSUrlSession session;


### PR DESCRIPTION
The download was failing because the original image url no longer exists.

I updated the image url to a working url that also uses https to abide by iOS App Transport Security